### PR TITLE
build(sdk): regenerate schema and Node.js SDK

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -20,7 +20,7 @@
         "@types/google-protobuf": "^3.15.12",
         "@types/mime": "^2.0.0",
         "@types/node": "^10.0.0",
-        "typescript": "^4.3.5"
+        "typescript": "^4.7.0"
     },
     "pulumi": {
         "resource": true,

--- a/sdk/nodejs/pcRestoreV2.ts
+++ b/sdk/nodejs/pcRestoreV2.ts
@@ -59,9 +59,9 @@ import * as utilities from "./utilities";
  *                     value: entry.value.ipv4[0].value,
  *                 }],
  *             })),
- *             ntpServers: .map(entry => ({
+ *             ntpServers: .map(entry2 => ({
  *                 fqdns: [{
- *                     value: entry.value.fqdn[0].value,
+ *                     value: entry2.value.fqdn[0].value,
  *                 }],
  *             })),
  *             externalAddress: {

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -1,16 +1,22 @@
 {
     "compilerOptions": {
+        // Output
         "outDir": "bin",
-        "target": "ES2020",
-        "module": "commonjs",
-        "moduleResolution": "node",
         "declaration": true,
+        "declarationMap": true,
         "sourceMap": true,
         "stripInternal": true,
-        "experimentalDecorators": true,
+        // Environment
+        "target": "ES2022",
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
+        "moduleDetection": "force",
+        "types": ["node"],
+        // Type Checking
+        "strict": true,
         "noFallthroughCasesInSwitch": true,
-        "forceConsistentCasingInFileNames": true,
-        "strict": true
+        "noImplicitReturns": true,
+        "skipLibCheck": true
     },
     "files": [
         "accessControlPolicy.ts",


### PR DESCRIPTION
## Summary

Regenerates schema.json and Node.js SDK files with the current provider configuration.

## Changes

- Update provider/cmd/pulumi-resource-nutanix/schema.json with latest schema
- Regenerate Node.js SDK files (pcRestoreV2.ts, tsconfig.json, package.json)

## Test Plan

- [ ] CI passes worktree-clean check
- [ ] SDK builds successfully