### PR TITLE
fix(ci): remove registry-url from setup-node to allow npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{matrix.nodeversion}}
-          registry-url: https://registry.npmjs.org
       - name: Setup DotNet
         uses: actions/setup-dotnet@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{matrix.nodeversion}}
-          registry-url: https://registry.npmjs.org
       - name: Setup DotNet
         uses: actions/setup-dotnet@v5
         with:
@@ -227,7 +226,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{matrix.nodeversion}}
-          registry-url: https://registry.npmjs.org
       - name: Setup DotNet
         uses: actions/setup-dotnet@v5
         with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -45,7 +45,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{matrix.nodeversion}}
-          registry-url: https://registry.npmjs.org
       - name: Setup DotNet
         uses: actions/setup-dotnet@v5
         with:


### PR DESCRIPTION
NODE_AUTH_TOKEN was being exported by setup-node when registry-url was set, causing npm to use stale token auth instead of the configured OIDC trusted publisher flow.
